### PR TITLE
Allow limiting the number of concurrent processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,29 @@ $results[2]; // contains 'result from task 3'
 
 The closures to run shouldn't return objects, only primitives and arrays are allowed.
 
+### Limiting the number of concurrent processes
+
+If you need to limit the number of concurrent processes, you can call `concurrent` with the maximum number of concurrent processes to execute, or `null` (the default) to allow unlimited processes. If set, `run` will execute the closures in groups of the provided size, in order.
+
+Use this when a large, or unknown number of processes will be ran (i.e. processing a large number of database results). Allowing unlimited process forks in this scenario would lead to very high CPU usage, and possibly hitting the user's max-process limit.
+
+You may find that in certain scenarios, limiting concurrency is more performant, due to the overhead associated with process forking (i.e. executing 1000 tasks is faster with a concurrency limit of 100).
+
+```php
+use Spatie\Fork\Fork;
+
+$results = Fork::new()
+    ->concurrent(2)
+    ->run(
+        // Concurrently executes the first 2 closures, and waits for them to complete
+        fn () => 1 + 1,
+        fn () => 2 + 2,
+
+        // Ran after the first 2 closures have completed their execution
+        fn () => 3 + 3,
+    );
+```
+
 ### Running code before and after each closure
 
 If you need to execute code some before or after each callable passed to `run`, you can pass a callable to `before` or `after`.  This callable passed  will be executed in the child process right before or after the callable passed to  `run` will execute.

--- a/src/Fork.php
+++ b/src/Fork.php
@@ -11,6 +11,8 @@ class Fork
 
     protected ?Closure $toExecuteAfterInChildTask = null;
     protected ?Closure $toExecuteAfterInParentTask = null;
+    
+    protected ?int $concurrent = null;
 
     public static function new(): self
     {
@@ -33,7 +35,28 @@ class Fork
         return $this;
     }
 
+    public function concurrent(?int $concurrent): self
+    {
+        $this->concurrent = $concurrent;
+
+        return $this;
+    }
+
     public function run(callable ...$callables): array
+    {
+        if ($this->concurrent === null) {
+            return $this->runCallables(...$callables);
+        }
+
+        $output = [];
+        foreach (array_chunk($callables, $this->concurrent, true) as $callableGroup) {
+            array_push($output, ...$this->runCallables(...$callableGroup));
+        }
+        
+        return $output;
+    }
+
+    protected function runCallables(callable ...$callables): array
     {
         $tasks = [];
 

--- a/tests/ForkTest.php
+++ b/tests/ForkTest.php
@@ -62,6 +62,34 @@ class ForkTest extends TestCase
     }
 
     /** @test */
+    public function it_can_limit_the_number_of_concurrent_tasks()
+    {
+        $results = Fork::new()
+            ->concurrent(2)
+            ->run(
+                function () {
+                    sleep(1);
+
+                    return 1 + 1;
+                },
+                function () {
+                    sleep(1);
+
+                    return 2 + 2;
+                },
+                function () {
+                    sleep(2);
+
+                    return 3 + 3;
+                },
+            );
+
+        $this->assertEquals([2, 4, 6], $results);
+
+        $this->assertTookGreaterThanSeconds(2);
+    }
+
+    /** @test */
     public function the_callable_given_to_before_runs_before_each_callable()
     {
         $results = Fork::new()
@@ -176,5 +204,14 @@ class ForkTest extends TestCase
         $usedTimeInSeconds = $currentTime - $this->startTime;
 
         $this->assertLessThan($expectedLessThanSeconds, $usedTimeInSeconds, "Took more than expected {$expectedLessThanSeconds} seconds");
+    }
+
+    protected function assertTookGreaterThanSeconds(int $expectedGreaterThanSeconds)
+    {
+        $currentTime = microtime(true);
+
+        $usedTimeInSeconds = $currentTime - $this->startTime;
+
+        $this->assertGreaterThan($expectedGreaterThanSeconds, $usedTimeInSeconds, "Took less than expected {$expectedGreaterThanSeconds} seconds");
     }
 }


### PR DESCRIPTION
Love this package.  However, when testing it for speeding up some of our tooling, I noticed that with performance degraded quickly with a larger number of processes.  This makes sense, since forking a process hundreds or thousands of times is an expensive operation.

The feature allows limiting that concurrency, so fewer concurrent processes are forked.  This drastically reduces CPU usage, since it doesn't have to manage so many processes and sockets.

During my testing, running 1000 concurrent tasks (that simply returned `foo`), took ~20 seconds.  Limiting it to 100 concurrent processes reduced that to 14 seconds.

### Possible Improvements

As implemented, it waits until all tasks of a concurrent group are completed before it starts the next group.  It may be better to kick off a group, and as each task completes, start the next task until all are complete.  However, this complicates things, and I am not convinced it would be any faster.  Though, that is a gut feeling, not backed by any tests.  

Open to suggestions. 