### PR TITLE
fixes socket_select interrupted exception 

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -4,6 +4,7 @@ namespace Spatie\Fork;
 
 use Generator;
 use Socket;
+use ErrorException;
 
 class Connection
 {
@@ -55,7 +56,15 @@ class Connection
 
             $except = null;
 
-            $selectResult = socket_select($read, $write, $except, $this->timeoutSeconds, $this->timeoutMicroseconds);
+            try {
+                $selectResult = socket_select($read, $write, $except, $this->timeoutSeconds, $this->timeoutMicroseconds);
+            } catch (ErrorException $e) {
+                if ($this->isInterruptionErrorException()) {
+                    continue;
+                }
+
+                throw $e;
+            }
 
             if ($selectResult === false) {
                 break;
@@ -90,7 +99,15 @@ class Connection
 
             $except = null;
 
-            $selectResult = socket_select($read, $write, $except, $this->timeoutSeconds, $this->timeoutMicroseconds);
+            try {
+                $selectResult = socket_select($read, $write, $except, $this->timeoutSeconds, $this->timeoutMicroseconds);
+            } catch (ErrorException $e) {
+                if ($this->isInterruptionErrorException()) {
+                    continue;
+                }
+
+                throw $e;
+            }
 
             if ($selectResult === false) {
                 break;
@@ -108,5 +125,10 @@ class Connection
 
             yield $outputFromSocket;
         }
+    }
+
+    private function isInterruptionErrorException(): bool
+    {
+        return 4 === socket_last_error();
     }
 }


### PR DESCRIPTION
As described in #31, when using pcntl_signal, socket_select may get interrupted which will cause an ErrorException being thrown. 

The message is: socket_select(): unable to select [4]: Interrupted system call.

With this fix, the ErrorException is catched, and when the error number is 4 (the interrupted system call), the while loop is continued and the socket_select is run again.

I have no tests, as this is very difficult to test as this appears to be occurring randomly. I have tested it manually however and the error seems to be gone. Also the existing unit tests still succeeds.