### PR TITLE
Support PHP 7.4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.1, 8.0]
+        php: [8.1, 8.0, 7.4]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^7.4|^8.0",
         "ext-sockets": "*",
         "ext-pcntl": "*"
     },

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -4,19 +4,29 @@ namespace Spatie\Fork;
 
 use ErrorException;
 use Generator;
-use Socket;
 
 class Connection
 {
+    /** @var \Socket */
+    protected $socket;
+
+    protected int $bufferSize = 1024;
+
+    protected float $timeout = 0.0001;
+
     protected int $timeoutSeconds;
+
     protected int $timeoutMicroseconds;
 
-    protected function __construct(
-        protected Socket $socket,
-        protected int $bufferSize = 1024,
-        protected float $timeout = 0.0001,
-    ) {
+    protected function __construct($socket, int $bufferSize = 1024, float $timeout = 0.0001)
+    {
+        $this->socket = $socket;
+
         socket_set_nonblock($this->socket);
+
+        $this->bufferSize = $bufferSize;
+
+        $this->timeout = $timeout;
 
         $this->timeoutSeconds = floor($this->timeout);
 

--- a/src/Fork.php
+++ b/src/Fork.php
@@ -26,7 +26,7 @@ class Fork
     public function __construct()
     {
         if (! function_exists('pcntl_fork')) {
-            throw new Exception("Cannot create process forks: PCNTL is not supported on this system.");
+            throw new Exception('Cannot create process forks: PCNTL is not supported on this system.');
         }
     }
 
@@ -103,7 +103,7 @@ class Fork
         return $this->forkForTask($task);
     }
 
-    protected function finishTask(Task $task): mixed
+    protected function finishTask(Task $task)
     {
         $output = $task->output();
 
@@ -143,10 +143,8 @@ class Fork
         return $pid === 0;
     }
 
-    protected function executeInChildTask(
-        Task $task,
-        Connection $connectionToParent,
-    ): void {
+    protected function executeInChildTask(Task $task, Connection $connectionToParent): void
+    {
         if ($this->toExecuteBeforeInChildTask) {
             ($this->toExecuteBeforeInChildTask)();
         }
@@ -173,9 +171,8 @@ class Fork
         $this->runningTasks[] = $this->runTask($firstTask);
     }
 
-    protected function startRunning(
-        Task ...$queue
-    ): void {
+    protected function startRunning(Task ...$queue): void
+    {
         $this->queue = $queue;
 
         foreach ($this->queue as $task) {

--- a/src/Task.php
+++ b/src/Task.php
@@ -87,7 +87,7 @@ class Task
         return $this;
     }
 
-    public function execute(): string | bool
+    public function execute(): string
     {
         $output = ($this->callable)();
 
@@ -95,10 +95,10 @@ class Task
             return $output;
         }
 
-        return self::SERIALIZATION_TOKEN . serialize($output);
+        return self::SERIALIZATION_TOKEN.serialize($output);
     }
 
-    public function output(): mixed
+    public function output()
     {
         foreach ($this->connection->read() as $output) {
             $this->output .= $output;
@@ -143,7 +143,7 @@ class Task
         return false;
     }
 
-    public function triggerSuccessCallback(): mixed
+    public function triggerSuccessCallback()
     {
         if (! $this->successCallback) {
             return null;

--- a/tests/ForkTest.php
+++ b/tests/ForkTest.php
@@ -39,11 +39,7 @@ it('will execute the given closure with concurrency cap ', function () {
 it('can execute the closures concurrently', function () {
     Fork::new()
         ->run(
-            ...array_fill(
-                start_index: 0,
-                count: 20,
-                value: fn () => usleep(100_000),
-            ) // 1/10th of a second each
+            ...array_fill(0, 20, fn () => usleep(100_000)) // 1/10th of a second each
         );
 
     assertTookLessThanSeconds(1);
@@ -87,7 +83,7 @@ test('the callable given to before can be run in the parent process', function (
     $value = 0;
 
     Fork::new()
-        ->before(parent: function () use (&$value) {
+        ->before(null, function () use (&$value) {
             $value++;
         })
         ->run(fn () => 1, fn () => 2);
@@ -99,7 +95,7 @@ test('the callable given to after can be run in the parent process', function ()
     $value = 0;
 
     Fork::new()
-        ->after(parent: function () use (&$value) {
+        ->after(null, function () use (&$value) {
             $value++;
         })
         ->run(fn () => 1, fn () => 2);
@@ -129,11 +125,9 @@ it('can return objects', function () {
 
 test('output in after', function () {
     Fork::new()
-        ->after(
-            parent: function (int $i) {
-                expect($i)->toEqual(1);
-            },
-        )
+        ->after(null, function (int $i) {
+            expect($i)->toEqual(1);
+        })
         ->run(
             fn () => 1
         );


### PR DESCRIPTION
Hello @freekmurze,

I would like to request your consideration for this PR that adds support for PHP 7.4.

As you may know, PHP 7.4 is still widely used, and many projects, including ours, still rely on it. Our project is large, and migrating to PHP 8 would be a major undertaking.

We would greatly appreciate your acceptance of this PR to help us continue to use the package with our current setup. 

Thank you for your time and consideration!