### PR TITLE
Kill any forked tasks when force closed in terminal

### DIFF
--- a/src/Fork.php
+++ b/src/Fork.php
@@ -157,11 +157,15 @@ class Fork
 
     protected function exit(): void
     {
-        if (extension_loaded('posix')) {
-            posix_kill(getmypid(), SIGKILL);
+        if (! extension_loaded('posix')) {
+            exit;
         }
 
-        exit;
+        foreach ($this->runningTasks as $task) {
+            posix_kill($task->pid(), SIGKILL);
+        }
+
+        posix_kill(getmypid(), SIGKILL);
     }
 
     protected function currentlyInChildTask(int $pid): bool

--- a/tests/ForkTest.php
+++ b/tests/ForkTest.php
@@ -11,7 +11,7 @@ it('will execute the given closures')
         )
     )->toEqual([2, 4]);
 
-it('will execute the given closure with concurrency cap ', function () {
+it('will execute the given closure with concurrency cap', function () {
     $results = Fork::new()
         ->concurrent(2)
         ->run(


### PR DESCRIPTION
I discovered that if you run one or more forked processes and force-terminate the parent running process in the CLI before the child (forked) processes finish, Fork won't terminate the stray running processes, leaving them running in the background.

This PR simply iterates through any running tasks if the CLI command is terminated and kills them via their PID.