### PR TITLE
Switch from kill-all-exit to a normal exit when a child is done

### DIFF
--- a/src/Fork.php
+++ b/src/Fork.php
@@ -129,7 +129,7 @@ class Fork
             try {
                 $this->executeInChildTask($task, $socketToParent);
             } finally {
-                $this->exit();
+                exit();
             }
         }
 

--- a/tests/ForkTest.php
+++ b/tests/ForkTest.php
@@ -138,3 +138,17 @@ test('output in after', function () {
             fn () => 1
         );
 });
+
+test('allow 2nd process to be done before the 1st')
+    ->expect(
+        fn () => Fork::new()->run(
+            static function () {
+                usleep(200_000);
+                return 2;
+            },
+            static function () {
+                usleep(100_000);
+                return 1;
+            },
+        )
+    )->toEqual([2,1]);


### PR DESCRIPTION
see #50 