### PR TITLE
Fix task exit status handling, uniformize process exit method and tests

### DIFF
--- a/src/Task.php
+++ b/src/Task.php
@@ -130,14 +130,13 @@ class Task
     {
         $this->output .= $this->connection->read()->current();
 
-        $status = pcntl_waitpid($this->pid(), $status, WNOHANG | WUNTRACED);
+        if (pcntl_waitpid($this->pid(), $status, WNOHANG | WUNTRACED) === $this->pid) {
 
-        if ($status === $this->pid) {
+            if (pcntl_wexitstatus($status) !== 0) {
+                throw CouldNotManageTask::make($this);
+            }
+
             return true;
-        }
-
-        if ($status !== 0) {
-            throw CouldNotManageTask::make($this);
         }
 
         return false;


### PR DESCRIPTION
In this commit I mainly updated the $status handling in Task.php because the same variable was used for 2 purposes.
I also added the thread exit with posix when enabled.
And because the pest --filter option still executes all the test which aren't wrapped in a callable I managed to refactor the test file to fix this.